### PR TITLE
Add benchmarking functions

### DIFF
--- a/src/rgv_tools/benchmarking/__init__.py
+++ b/src/rgv_tools/benchmarking/__init__.py
@@ -1,3 +1,3 @@
-from ._metrics import get_time_correlation, get_velocity_correlation
+from ._metrics import get_grn_auroc, get_time_correlation, get_velocity_correlation
 
-__all__ = ["get_time_correlation", "get_velocity_correlation"]
+__all__ = ["get_grn_auroc", "get_time_correlation", "get_velocity_correlation"]

--- a/src/rgv_tools/benchmarking/_metrics.py
+++ b/src/rgv_tools/benchmarking/_metrics.py
@@ -3,6 +3,7 @@ from typing import Callable
 import numpy as np
 import scipy
 from numpy.typing import ArrayLike
+from sklearn.metrics import roc_auc_score
 
 
 def pearsonr(x: ArrayLike, y: ArrayLike, axis: int = 0) -> ArrayLike:
@@ -74,3 +75,24 @@ def get_time_correlation(ground_truth: ArrayLike, estimated: ArrayLike) -> float
     Spearman correlation.
     """
     return scipy.stats.spearmanr(ground_truth, estimated)[0]
+
+
+def get_grn_auroc(ground_truth: ArrayLike, estimated: ArrayLike) -> float:
+    """Compute AUROC for .
+
+    Parameters
+    ----------
+    ground_truth
+        Array of ground truth value.
+    estimated
+        Array of estimated values.
+
+    Returns
+    -------
+    AUROC score.
+    """
+    mask = np.where(~np.eye(ground_truth.shape[0], dtype=bool))
+    ground_truth = ground_truth[mask].astype(bool).astype(float)
+    ground_truth[ground_truth != 0] = 1
+
+    return roc_auc_score(ground_truth, estimated[mask])


### PR DESCRIPTION
## New

<!-- Please give section if this PR does not implement a new feature -->

- Adds `get_velocity_correlation` to compute pairwise correlations between ground truth and estimated velocities
- Adds `get_time_correlation` to compute Spearman correlation between ground truth and estimated latent time
- Adds `get_grn_auroc` to compute AUROC metric to assess GRN inference

## Related issues

<!-- Please list related issues. If none exist, open one and reference it here. -->

Closes #31.
